### PR TITLE
metadata: add 44 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "41",
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/G-dH/overview-feature-pack",
   "uuid": "overview-feature-pack@G-dH.github.com",


### PR DESCRIPTION
I've added the "44" tag to the `metadata.json` file of my local installation of OFP and I've been using a it on GNOME 44 for a few days without any issues.

Thanks for developing OFP 🚀 